### PR TITLE
Change container port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+venv
+build
+*.db
+

--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-examples/
 pytest.ini
 .DS_store
 *.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=18080
+EXPOSE 18080
+
+CMD ["sh", "-c", "uvicorn examples.run:app --host 0.0.0.0 --port ${PORT}"]
+

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ uvicorn run:app
 
 NOTE: You have to expose the host:port to where the LINE API server can access.
 
+## 🐳 Docker
+
+以下のコマンドでコンテナイメージをビルドし、起動できます。
+
+```sh
+docker build -t linedify .
+docker run -p 18080:18080 \
+  -e LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN \
+  -e LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET \
+  -e DIFY_API_KEY=DIFY_API_KEY \
+  -e DIFY_BASE_URL=DIFY_BASE_URL \
+  -e DIFY_USER=DIFY_USER \
+  linedify
+```
+
+デフォルトの待ち受けポートは`18080`です。変更したい場合は、`PORT`環境変数で上書きしてください。
+
+
 
 ## 🕹️ Switching Types
 

--- a/examples/run.py
+++ b/examples/run.py
@@ -1,0 +1,29 @@
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, Request, BackgroundTasks
+from linedify import LineDify
+import os
+
+line_dify = LineDify(
+    line_channel_access_token=os.environ.get("LINE_CHANNEL_ACCESS_TOKEN", ""),
+    line_channel_secret=os.environ.get("LINE_CHANNEL_SECRET", ""),
+    dify_api_key=os.environ.get("DIFY_API_KEY", ""),
+    dify_base_url=os.environ.get("DIFY_BASE_URL", ""),
+    dify_user=os.environ.get("DIFY_USER", ""),
+)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await line_dify.shutdown()
+
+app = FastAPI(lifespan=lifespan)
+
+@app.post("/linebot")
+async def handle_request(request: Request, background_tasks: BackgroundTasks):
+    background_tasks.add_task(
+        line_dify.process_request,
+        request_body=(await request.body()).decode("utf-8"),
+        signature=request.headers.get("X-Line-Signature", "")
+    )
+    return "ok"
+


### PR DESCRIPTION
## Summary
- use port 18080 in Dockerfile and README
- allow overriding port via `PORT` env var

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68797989373c832f858e3dd9af0440a5