### PR TITLE
Add environment variable example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+LINE_CHANNEL_ACCESS_TOKEN=
+LINE_CHANNEL_SECRET=
+DIFY_API_KEY=
+DIFY_BASE_URL=
+DIFY_USER=
+# Optional: path to an image file for tests
+DIFY_IMAGE_PATH=tests/resources/catgirl.png
+# Optional: port for the FastAPI server
+PORT=18080

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ uvicorn run:app
 
 NOTE: You have to expose the host:port to where the LINE API server can access.
 
+## 🔧 Environment Variables
+
+Copy `.env.example` to `.env` and set the following variables:
+
+- `LINE_CHANNEL_ACCESS_TOKEN`
+- `LINE_CHANNEL_SECRET`
+- `DIFY_API_KEY`
+- `DIFY_BASE_URL`
+- `DIFY_USER`
+- *(optional)* `DIFY_IMAGE_PATH` - path to an image file for tests
+- *(optional)* `PORT` - server port (default `18080`)
+
 ## 🐳 Docker
 
 以下のコマンドでコンテナイメージをビルドし、起動できます。


### PR DESCRIPTION
## Summary
- add `.env.example`
- document environment variables in README

## Testing
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68798546788c832fa83e5aebf1a95fb6