### PR TITLE
特定roomのみ処理する機能の追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ LINE_CHANNEL_SECRET=
 DIFY_API_KEY=
 DIFY_BASE_URL=
 DIFY_USER=
+# Optional: limit bot to a specific room
+TARGET_ROOM_ID=
 # Optional: path to an image file for tests
 DIFY_IMAGE_PATH=tests/resources/catgirl.png
 # Optional: port for the FastAPI server

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ By passing the HTTP request body and signature to `line_dify.process_request`, t
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, BackgroundTasks
 from linedify import LineDify
+import os
 
 # LINE Bot - Dify Agent Integrator
 line_dify = LineDify(
@@ -47,6 +48,13 @@ line_dify = LineDify(
     dify_base_url=DIFY_BASE_URL,    # e.g. http://localhost/v1
     dify_user=DIFY_USER
 )
+
+TARGET_ROOM_ID = os.getenv("TARGET_ROOM_ID")
+
+@line_dify.validate_event
+async def validate_event(event):
+    if TARGET_ROOM_ID and event.source.type == "room" and event.source.room_id != TARGET_ROOM_ID:
+        return []
 
 # FastAPI
 @asynccontextmanager
@@ -85,6 +93,7 @@ Copy `.env.example` to `.env` and set the following variables:
 - `DIFY_USER`
 - *(optional)* `DIFY_IMAGE_PATH` - path to an image file for tests
 - *(optional)* `PORT` - server port (default `18080`)
+- *(optional)* `TARGET_ROOM_ID` - room ID the bot responds to
 
 ## 🐳 Docker
 
@@ -98,6 +107,7 @@ docker run -p 8443:8443 \
   -e DIFY_API_KEY=DIFY_API_KEY \
   -e DIFY_BASE_URL=DIFY_BASE_URL \
   -e DIFY_USER=DIFY_USER \
+  -e TARGET_ROOM_ID=YOUR_ROOM_ID \
   -e PORT=8443 \
   linedify
 ```

--- a/examples/run.py
+++ b/examples/run.py
@@ -11,6 +11,14 @@ line_dify = LineDify(
     dify_user=os.environ.get("DIFY_USER", ""),
 )
 
+# Room ID to accept messages from
+TARGET_ROOM_ID = os.environ.get("TARGET_ROOM_ID")
+
+@line_dify.validate_event
+async def validate_event(event):
+    if TARGET_ROOM_ID and event.source.type == "room" and event.source.room_id != TARGET_ROOM_ID:
+        return []
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield


### PR DESCRIPTION
## Summary
- `TARGET_ROOM_ID` 環境変数を追加し、指定したroomだけ受け付けるように`examples/run.py`を修正
- READMEにroom制限の説明とコード例、Docker実行例を追記
- `.env.example` に `TARGET_ROOM_ID` を追加

## Testing
- `pip3 install --break-system-packages -q -r requirements-dev.txt` *(失敗: ネットワークに接続できず)*
- `pytest -q` *(失敗: pytestがインストールされていないため実行不可)*

------
https://chatgpt.com/codex/tasks/task_e_6879e203fbf4832f83ebd4fe0a2b84ff