### PR TITLE
Add env-based verbose logging toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ LINE_CHANNEL_SECRET=
 DIFY_API_KEY=
 DIFY_BASE_URL=
 DIFY_USER=
+# Optional: enable verbose logging
+LINEDIFY_VERBOSE=false
 # Optional: limit bot to a specific room
 TARGET_ROOM_ID=
 # Optional: path to an image file for tests

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Copy `.env.example` to `.env` and set the following variables:
 - *(optional)* `DIFY_IMAGE_PATH` - path to an image file for tests
 - *(optional)* `PORT` - server port (default `18080`)
 - *(optional)* `TARGET_ROOM_ID` - room ID the bot responds to
+- *(optional)* `LINEDIFY_VERBOSE` - set to `true` to enable verbose logging
 
 ## 🐳 Docker
 
@@ -108,6 +109,7 @@ docker run -p 8443:8443 \
   -e DIFY_BASE_URL=DIFY_BASE_URL \
   -e DIFY_USER=DIFY_USER \
   -e TARGET_ROOM_ID=YOUR_ROOM_ID \
+  -e LINEDIFY_VERBOSE=true \
   -e PORT=8443 \
   linedify
 ```
@@ -281,7 +283,7 @@ line_dify = LineDify(
 
 ## 🐝 Debug
 
-Set `verbose=True` to see the request and response, both from/to LINE and from/to Dify.
+Set `verbose=True` or environment variable `LINEDIFY_VERBOSE=true` to see the request and response, both from/to LINE and from/to Dify.
 
 ```python
 line_dify = LineDify(

--- a/linedify/integration.py
+++ b/linedify/integration.py
@@ -1,7 +1,8 @@
 import json
 from logging import getLogger, NullHandler
 from traceback import format_exc
-from typing import Dict, List, Tuple, Union
+import os
+from typing import Dict, List, Tuple, Union, Optional
 
 from linebot.v3 import WebhookParser
 from linebot.v3.messaging import (
@@ -40,8 +41,15 @@ class LineDifyIntegrator:
         dify_type: DifyType = DifyType.Agent,
         session_db_url: str = "sqlite:///sessions.db",
         session_timeout: float = 3600.0,
-        verbose: bool = False
+        verbose: Optional[bool] = None
     ) -> None:
+
+        if verbose is None:
+            env_verbose = os.getenv("LINEDIFY_VERBOSE")
+            if env_verbose is not None:
+                verbose = env_verbose.lower() in ("1", "true", "yes", "on")
+            else:
+                verbose = False
 
         self.verbose = verbose
 


### PR DESCRIPTION
## Summary
- allow setting `LINEDIFY_VERBOSE` to control verbose logging
- document new variable in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - linedify, linebot)*

------
https://chatgpt.com/codex/tasks/task_e_6879e4f2830c832fa8f9c2662e0dd872